### PR TITLE
use `lerna ls` instead of `lerna updated`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install --global lerna-current-dir-updated
 
 ## Usage
 
-`lerna-current-dir-updated` and `lerna-current-dir-not-updated` accept the same flags as the [lerna updated](https://github.com/lerna/lerna#updated) command.
+`lerna-current-dir-updated` and `lerna-current-dir-not-updated` accept the same flags as the [lerna list](https://github.com/lerna/lerna/tree/master/commands/list) command.
 
 ### `lerna-current-dir-updated`
 

--- a/src/getUpdatedPackages.js
+++ b/src/getUpdatedPackages.js
@@ -2,15 +2,8 @@ import { execSync } from 'child_process';
 
 export default function getUpdatedPackages(options = {}) {
   const args = options.arguments || [];
-  try {
-    return JSON.parse(
-      execSync(`lerna updated ${args.join(' ')} --json`, { stdio: 'pipe' }).toString()
-    );
-  } catch(e) {
-    if (e.stderr.toString().includes('No packages')) {
-      return [];
-    } else {
-      throw e;
-    }
-  }
+
+  return JSON.parse(
+    execSync(`lerna ls ${args.join(' ')} --json`, { stdio: 'pipe' }).toString()
+  );
 }


### PR DESCRIPTION
The latest major version of lerna (v3.0.0) changes the semantics of `lerna updated|changed` and no longer accepts the `--since` flag. These commands are now only meant to report what _would_ be published if `lerna publish|version` were run. See issue comment: https://github.com/lerna/lerna/issues/1544#issuecomment-412144740

An alternative to relying on `lerna updated --since <commit>` is to use one of the many ways with `git` to check what has changed since a given revision.

This PR searches the results of executing `git diff --name-only <commit>` to acheive the same behavior.
